### PR TITLE
Rename page title

### DIFF
--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>ember-key-navigation</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>ember-key-navigation</title>
+    <title>Ember Key Navigation</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Let me know if you prefer `ember-key-navigation` or `Ember Key Navigation` because the dummy app seems to have that as the heading.